### PR TITLE
Strict dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 rvm:
-  - 2.0.0-p598
-  - 2.1.5
-  - 2.2.0
-gemfile:
-  - Gemfile
-  - gemfiles/faraday-0_8_8.gemfile
+  - 2.0.0-p648
+  - 2.1.9
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 sudo: false
 cache: bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,90 @@
+PATH
+  remote: .
+  specs:
+    octoparts (0.0.8)
+      activesupport (> 4.0.0)
+      faraday (~> 0.11)
+      representable (~> 2.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.7.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    coderay (1.1.1)
+    coveralls (0.8.19)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.12.0)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+      tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    docile (1.1.5)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.2)
+    i18n (0.7.0)
+    json (1.8.6)
+    method_source (0.8.2)
+    mini_portile (0.6.1)
+    minitest (5.10.1)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    nokogiri (1.6.5)
+      mini_portile (~> 0.6.0)
+    power_assert (0.4.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (2.0.5)
+    rake (10.5.0)
+    representable (2.1.4)
+      multi_json
+      nokogiri
+      uber (~> 0.0.7)
+    safe_yaml (1.0.4)
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    slop (3.6.0)
+    term-ansicolor (1.4.0)
+      tins (~> 1.0)
+    test-unit (3.2.3)
+      power_assert
+    thor (0.19.4)
+    thread_safe (0.3.5)
+    tins (1.13.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uber (0.0.13)
+    vcr (3.0.3)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.7)
+  coveralls
+  octoparts!
+  pry
+  rake (~> 10.0)
+  test-unit (~> 3.0)
+  vcr
+  webmock
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    octoparts (0.0.8)
+    octoparts (0.0.9)
       activesupport (> 4.0.0)
       faraday (~> 0.11)
       representable (~> 2.1)

--- a/gemfiles/faraday-0_8_8.gemfile
+++ b/gemfiles/faraday-0_8_8.gemfile
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'faraday', '~> 0.8.8'
-gemspec path: '../'

--- a/lib/octoparts/version.rb
+++ b/lib/octoparts/version.rb
@@ -1,3 +1,3 @@
 module Octoparts
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/octoparts.gemspec
+++ b/octoparts.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "representable"
+  spec.add_dependency "representable", '~> 2.1'
   spec.add_dependency "activesupport", "> 4.0.0"
-  spec.add_dependency "faraday"
+  spec.add_dependency "faraday", '~> 0.11'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
`octoparts` does not work with `representable` >= 3.0.0.

Therefore,
- Added specification in *.gemspec to ensure compatible `representable` is installed.
- Commited `Gemfile.lock` to ensure test is executed with compatible `representable`

--

`octoparts` は依存した gemの `representable` のバージョンが v3.0.0 以降だと動作しません。
そこで、

- `representable`のバージョンを *.gemspecで指定しました。.
- `Gemfile.lock`をコミットし、テストでは`representable`の互換性のあるバージョンが実行されるようにしました。

